### PR TITLE
 ユーザ情報画面のURL, FOLLOWING, FOLLOWERS, LISTED, Edit profileがタップできないバグ修正

### DIFF
--- a/Binding/src/binding.ts
+++ b/Binding/src/binding.ts
@@ -1,6 +1,7 @@
 export interface MarinDeckBindingsInterface {
     openSettings(): void
     alert(text: string): void
+    openUrl(url: string): void
 }
 
 export class MarinDeckBindings implements MarinDeckBindingsInterface {
@@ -15,6 +16,13 @@ export class MarinDeckBindings implements MarinDeckBindingsInterface {
         window.MD.Native.post({
             type: "presentAlert",
             body: { text: text }
+        })
+    }
+
+    openUrl(url: string): void {
+        window.MD.Native.post({
+            type: "openUrl",
+            body: { url: url }
         })
     }
 }

--- a/Binding/src/marindeck.js
+++ b/Binding/src/marindeck.js
@@ -81,7 +81,10 @@ const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
                     }
                 }
             })
-        }).observe(document.body, {childList: true, subtree: true})
+        }).observe(document.body, {
+            childList: true,
+            subtree: true
+        })
     }
 
 })();
@@ -89,7 +92,9 @@ const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
 function isTweetButtonHidden(bool) {
     window.MD.Native.post({
         type: 'isTweetButtonHidden',
-        body: { value: bool }
+        body: {
+            value: bool
+        }
     })
 }
 
@@ -138,7 +143,7 @@ function loginStyled() {
     document.querySelector(".js-signin-ui .Button").style.outline = "none"
 
     document.querySelectorAll(".app-signin-wrap")[1].style.width = "100%";
-    
+
     document.querySelector(".startflow-link").removeAttribute("target");
 
     isTweetButtonHidden(true)
@@ -152,7 +157,9 @@ function swiftLog(...msg) {
 
     window.MD.Native.post({
         type: 'jsCallbackHandler',
-        body: { value: msg }
+        body: {
+            value: msg
+        }
     })
 }
 
@@ -175,18 +182,18 @@ function positionElement(x, y) {
     element.parentElement.parentElement.querySelectorAll(".js-media-image-link").forEach(function (item, index) {
         if (item === element) {
             selectIndex = index
-            
-//            const obj = item.querySelector("img")
-//           
-//            var cvs = document.createElement('canvas');
-//            cvs.width  = obj.width;
-//            cvs.height = obj.height;
-//            var ctx = cvs.getContext('2d');
-//            ctx.drawImage(obj, 0, 0);
-//           
-//            const data = cvs.toDataURL("image/png");
-//            webkit.messageHandlers.selectedImageBase64.postMessage(data);
-            
+
+            //            const obj = item.querySelector("img")
+            //           
+            //            var cvs = document.createElement('canvas');
+            //            cvs.width  = obj.width;
+            //            cvs.height = obj.height;
+            //            var ctx = cvs.getContext('2d');
+            //            ctx.drawImage(obj, 0, 0);
+            //           
+            //            const data = cvs.toDataURL("image/png");
+            //            webkit.messageHandlers.selectedImageBase64.postMessage(data);
+
         }
         const img = item.style.backgroundImage
         if (img === "") {
@@ -194,24 +201,26 @@ function positionElement(x, y) {
         } else {
             imgUrls.push(img);
         }
-        
+
         const rect = item.getBoundingClientRect()
         positions.push([rect.left, rect.top, rect.width, rect.height])
     })
 
-//    var rect = element.getBoundingClientRect();
-//    console.log(rect);
-/* Ex
-        ([
-         [left, right, width, height],
-         [left, right, width, height],
-         [left, right, width, height]
-        ], selectIndex)
- */
+    //    var rect = element.getBoundingClientRect();
+    //    console.log(rect);
+    /* Ex
+            ([
+             [left, right, width, height],
+             [left, right, width, height],
+             [left, right, width, height]
+            ], selectIndex)
+     */
 
     window.MD.Native.post({
         type: 'imageViewPos',
-        body: { positions: positions }
+        body: {
+            positions: positions
+        }
     })
 
     return [selectIndex, imgUrls]
@@ -221,6 +230,7 @@ function positionElement(x, y) {
     await sleep(800);
 
     let endedlist = []
+    let subscribedActionUrls = []
 
     const isNativeImageModal = await window.MD.Native.get({
         type: "config",
@@ -230,7 +240,7 @@ function positionElement(x, y) {
         }
     })
 
-    new MutationObserver( _ => {
+    new MutationObserver(_ => {
         document.querySelectorAll(".js-media-image-link").forEach(function (image) {
             if (endedlist.indexOf(image) === -1) {
                 endedlist.push(image);
@@ -241,7 +251,9 @@ function positionElement(x, y) {
                             const url = clickedItem.target.href
                             window.MD.Native.post({
                                 type: 'openYoutube',
-                                body: { url: url }
+                                body: {
+                                    url: url
+                                }
                             })
                         })
                     }
@@ -254,7 +266,7 @@ function positionElement(x, y) {
 
                             window.MD.Native.post({
                                 type: 'imagePreviewer',
-                                body: { 
+                                body: {
                                     selectedIndex: res[0],
                                     imageUrls: res[1]
                                 }
@@ -264,5 +276,19 @@ function positionElement(x, y) {
                 }
             }
         });
-    }).observe(document.body, {childList: true, subtree: true})
+
+        // FIXME: Array.from
+        Array.from(document.getElementsByClassName("js-action-url")).forEach((element) => {
+            if (!subscribedActionUrls.includes(element.href)) {
+                subscribedActionUrls.push(element.href);
+                console.log("subscribed", element.href)
+                element.addEventListener("click", e => {
+                    window.Bindings.openUrl(e.currentTarget.href);
+                })
+            }
+        })
+    }).observe(document.body, {
+        childList: true,
+        subtree: true
+    })
 })();

--- a/Marindeck/Const/JSCallbackFlag.swift
+++ b/Marindeck/Const/JSCallbackFlag.swift
@@ -19,4 +19,5 @@ enum JSCallbackFlag: String, CaseIterable, Codable {
     case openYoutube = "openYoutube"
     case sidebar = "sidebar"
     case config = "config"
+    case openUrl = "openUrl"
 }

--- a/Marindeck/View/Core/ViewController+WKScriptMessageHandler.swift
+++ b/Marindeck/View/Core/ViewController+WKScriptMessageHandler.swift
@@ -158,6 +158,11 @@ extension ViewController: WKScriptMessageHandler {
                 let value = userDefaults.dictionary(forKey: .jsConfig)?[key]
                 td.actions.send(uuid: uuid ?? "", value: value)
             } else {}
+        case .openUrl:
+            guard let url = body?["url"] as? String else { return }
+            let vc = ModalBrowserViewController()
+            vc.url = url
+            present(vc, animated: true)
 
         case .none:
             Loaf("予期しないTypeを受信しました: \(typeCast)", state: .error, location: .top, sender: self).show()

--- a/Marindeck/View/Other/ModalBrowserViewController.swift
+++ b/Marindeck/View/Other/ModalBrowserViewController.swift
@@ -82,14 +82,7 @@ class ModalBrowserViewController: UIViewController, WKUIDelegate, WKNavigationDe
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-//        let url = navigationAction.request.url
-
-//        if !(url?.path.contains("/settings") ?? true) || !(url?.host == "mobile.twitter.com") {
-//            decisionHandler(.cancel)
-//            self.dismiss(animated: true, completion: nil)
-//        } else {
             decisionHandler(.allow)
-//        }
     }
 }
 

--- a/Marindeck/View/Other/ModalBrowserViewController.swift
+++ b/Marindeck/View/Other/ModalBrowserViewController.swift
@@ -1,0 +1,95 @@
+//
+//  ModalBrowserViewController.swift
+//  Marindeck
+//
+//  Created by a on 12/13/22.
+//
+
+import UIKit
+import WebKit
+
+class ModalBrowserViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
+    public var url: String = ""
+    
+    var webView: WKWebView!
+    lazy var dismissButton: UIButton = {
+        let btn = UIButton()
+        let cf = UIImage.SymbolConfiguration(pointSize: 28, weight: .medium, scale: .default)
+        btn.setImage(UIImage(systemName: "xmark.circle.fill", withConfiguration: cf), for: .normal)
+        btn.tintColor = .label
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+
+    override func loadView() {
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        webView.uiDelegate = self
+        webView.navigationDelegate = self
+        view = webView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(dismissButton)
+
+        NSLayoutConstraint.activate([
+            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 12),
+            dismissButton.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -12),
+            dismissButton.widthAnchor.constraint(equalToConstant: 28),
+            dismissButton.heightAnchor.constraint(equalToConstant: 28)
+        ])
+
+        dismissButton.addTarget(self, action: #selector(onDismiss), for: .touchUpInside)
+
+        view.bringSubviewToFront(webView)
+
+        let myURL = URL(string: url)
+        let request = URLRequest(url: myURL!)
+
+        let jsonString = """
+                         [{
+                           "trigger": {
+                             "url-filter": ".*"
+                           },
+                           "action": {
+                             "type": "css-display-none",
+                             "selector": "#layers"
+                           }
+                         }]
+                         """
+
+        WKContentRuleListStore.default().compileContentRuleList(forIdentifier: "ContentBlockingRules", encodedContentRuleList: jsonString) { rulesList, error in
+            if let error = error {
+                print(error)
+                return
+            }
+            guard let rulesList = rulesList else {
+                return
+            }
+            let config = self.webView.configuration
+            config.userContentController.add(rulesList)
+            self.webView.load(request)
+        }
+    }
+
+    @objc
+    func onDismiss() {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+//        let url = navigationAction.request.url
+
+//        if !(url?.path.contains("/settings") ?? true) || !(url?.host == "mobile.twitter.com") {
+//            decisionHandler(.cancel)
+//            self.dismiss(animated: true, completion: nil)
+//        } else {
+            decisionHandler(.allow)
+//        }
+    }
+}
+

--- a/Marindeck/js/marindeck.js
+++ b/Marindeck/js/marindeck.js
@@ -84,13 +84,18 @@ const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
           }
         }
       });
-    }).observe(document.body, { childList: true, subtree: true });
+    }).observe(document.body, {
+      childList: true,
+      subtree: true
+    });
   }
 })();
 function isTweetButtonHidden(bool) {
   window.MD.Native.post({
     type: "isTweetButtonHidden",
-    body: { value: bool }
+    body: {
+      value: bool
+    }
   });
 }
 function loginStyled() {
@@ -129,7 +134,9 @@ function swiftLog(...msg) {
   console.log("JS Log:", msg);
   window.MD.Native.post({
     type: "jsCallbackHandler",
-    body: { value: msg }
+    body: {
+      value: msg
+    }
   });
 }
 function positionElement(x, y) {
@@ -159,13 +166,16 @@ function positionElement(x, y) {
   });
   window.MD.Native.post({
     type: "imageViewPos",
-    body: { positions }
+    body: {
+      positions
+    }
   });
   return [selectIndex, imgUrls];
 }
 (async () => {
   await sleep(800);
   let endedlist = [];
+  let subscribedActionUrls = [];
   const isNativeImageModal = await window.MD.Native.get({
     type: "config",
     body: {
@@ -183,7 +193,9 @@ function positionElement(x, y) {
               const url = clickedItem.target.href;
               window.MD.Native.post({
                 type: "openYoutube",
-                body: { url }
+                body: {
+                  url
+                }
               });
             });
           }
@@ -204,7 +216,20 @@ function positionElement(x, y) {
         }
       }
     });
-  }).observe(document.body, { childList: true, subtree: true });
+    Array.from(document.getElementsByClassName("js-action-url")).forEach((element) => {
+      if (!subscribedActionUrls.includes(element.href)) {
+        subscribedActionUrls.push(element.href);
+        console.log("subscribed", element.href);
+        element.addEventListener("click", (e) => {
+          console.log("marindeck.js, tapped action url", e.currentTarget.href);
+          window.Bindings.openUrl(e.currentTarget.href);
+        });
+      }
+    });
+  }).observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 })();
 class MarinDeckBindings {
   openSettings() {
@@ -217,6 +242,12 @@ class MarinDeckBindings {
     window.MD.Native.post({
       type: "presentAlert",
       body: { text }
+    });
+  }
+  openUrl(url) {
+    window.MD.Native.post({
+      type: "openUrl",
+      body: { url }
     });
   }
 }


### PR DESCRIPTION
## 概要
- fixed #49 

## 対応
`.js-action-url`のclickイベントを取得して`Bindings.openUrl`を呼び出してwebViewのモーダルを出すようにした。

## このPRで対応していないもの
- webViewのモーダルを出すだけの処理なので、遷移したり他のブラウザで開くみたいな処理はいれてない

